### PR TITLE
Fix plugins link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 |
 <b><a href="/docs/README.md">Documentation</a></b>
 |
-<b><a href="wiki/Plugins">Plugins</a></b>
+<b><a href="https://github.com/flyjs/fly/wiki#plugins">Plugins</a></b>
 |
 <b><a href="#contributing">Contributing</a></b>
 </p>


### PR DESCRIPTION
Old link was `https://github.com/flyjs/fly/blob/master/wiki/Plugins` 
