### PR TITLE
Add babel in devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "yieldables": "^0.2.0"
   },
   "devDependencies": {
+    "babel": "^5.6.14",
     "babel-eslint": "^3.1.9",
     "eslint": "^0.21.2",
     "tap-spec": "^4.0.2",


### PR DESCRIPTION
Build failed when run `npm run buid`.

```
% npm run build
...
sh: babel: command not found
```
