### PR TITLE
Update fly-uglify version in examples

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -14,7 +14,7 @@
     "fly-coffee": "0.0.1",
     "fly-eslint": "0.0.1",
     "fly-mocha": "0.0.1",
-    "fly-uglify": "0.0.1"
+    "fly-uglify": "0.0.2"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
In previous status `npm i` displayed an error like [this](https://github.com/bucaran/fly-uglify/pull/1). Update fly-uglify version in examples, then it fixed for tring to use `fly`. Thanks.
