### PR TITLE
Conditional time scale for task duration

### DIFF
--- a/src/reporter.js
+++ b/src/reporter.js
@@ -25,7 +25,7 @@ export default function () {
 
   .on("task_complete", ({ task, duration }) => {
     var scale = "ms";
-    if (duration > 1000) {
+    if (duration >= 1000) {
      var duration = Math.round((duration / 1000) * 10) / 10;
       scale = "s";
     }

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -23,9 +23,14 @@ export default function () {
   .on("task_start", ({ task }) =>
     log(`Starting ${fmt.start}`, task))
 
-  .on("task_complete", ({ task, duration }) =>
-    log(`Finished ${fmt.complete} in ${fmt.secs}`, task, duration, "ms"))
-
+  .on("task_complete", ({ task, duration }) => {
+    var scale = "ms";
+    if (duration > 1000) {
+     var duration = Math.round((duration / 1000) * 10) / 10;
+      scale = "s";
+    }
+    log(`Finished ${fmt.complete} in ${fmt.secs}`, task, duration, scale))
+  }
   .on("task_not_found", ({ task }) =>
     log(`${fmt.error} not found in Flyfile.`, task))
 

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -29,8 +29,8 @@ export default function () {
      var duration = Math.round((duration / 1000) * 10) / 10;
       scale = "s";
     }
-    log(`Finished ${fmt.complete} in ${fmt.secs}`, task, duration, scale))
-  }
+    log(`Finished ${fmt.complete} in ${fmt.secs}`, task, duration, scale)
+  })
   .on("task_not_found", ({ task }) =>
     log(`${fmt.error} not found in Flyfile.`, task))
 


### PR DESCRIPTION
Addresses https://github.com/flyjs/fly/issues/33. If `duration` is greater than or equal to `1000` then it will convert it to seconds and round to the nearest tenth's place. It will then pass `"s"` instead of `"ms"` to the the `log` function.

I put this in `reporter.js` instead of `fly.js` so that the actual conversion and if statement doesn't potentially effect the duration itself.
