### PR TITLE
Fix plugins link in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@
 |
 <b><a href="#api">API</a></b>
 |
-<b><a href="#plugins-1">Plugins</a></b>
+<b><a href="#plugins">Plugins</a></b>
 |
 <b><a href="#hacking">Hacking</a></b>
 |


### PR DESCRIPTION
Documentation is looking a lot better! The link to the plugins section was broken though, so here's a fix.
