### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -345,7 +345,7 @@ module.exports = function () {
 module.exports = function () {
   return this.filter("myFilter", (source, options) => {
     try {
-      return tranform → source
+      return transform(source)
     } catch (e) { throw e }
   })
 }


### PR DESCRIPTION
Or should just use `transform(source)`
