### PR TITLE
Fix this.unwrap usage with multiple entry points

### DIFF
--- a/src/fly.js
+++ b/src/fly.js
@@ -87,7 +87,7 @@ export default class Fly extends Emitter {
   unwrap (onFulfilled, onRejected) {
     return new Promise((resolve, reject) => {
       return Promise.all(this._.globs.map(glob => expand(glob)))
-        .then((files) => resolve.apply(this, files)).catch(reject)
+        .then((files) => resolve.call(this, files.reduce((arr, item) => arr.concat(item)))).catch(reject)
       }).then(onFulfilled).catch(onRejected)
   }
   /**

--- a/test/fly.js
+++ b/test/fly.js
@@ -117,8 +117,10 @@ test("✈  fly.watch", (t) => {
 })
 
 test("✈  fly.unwrap", (t) => {
-  t.plan(2)
-  const files = ["a.x", "b.x", "c.x"]
+  t.plan(4)
+  const files_x = ["a.x", "b.x", "c.x"]
+  const files_y = ["a.y", "b.y", "c.y"]
+  const files = files_x.concat(files_y)
   const paths = files.map((file) => {
     const path = join(__dirname, "fixtures", file)
     touch(path)
@@ -126,8 +128,14 @@ test("✈  fly.unwrap", (t) => {
   })
   const fly = new Fly()
   co(function* () {
-    const result = yield fly.source("*.x").unwrap((f) => {
-      t.deepEqual(f, files, "unwrap source globs")
+    yield fly.source("*.x").unwrap((f) => {
+      t.deepEqual(f, files_x, "unwrap source globs with single entry point")
+    })
+    yield fly.source(["*.y"]).unwrap((f) => {
+      t.deepEqual(f, files_y, "unwrap source globs with single entry point in array")
+    })
+    const result = yield fly.source(["*.x", "*.y"]).unwrap((f) => {
+      t.deepEqual(f, files, "unwrap source globs with multiple entry points")
       return 42
     })
     t.equal(result, 42, "result is the return value from fulfilled handler")


### PR DESCRIPTION
Without this fix `fly.source(["*.x", "*.y"]).unwrap` return only `*.x` files.
