### PR TITLE
Silence npm warnings about duplicate rimraf dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "tap-spec": "*",
     "tape": "*",
     "touch": "*",
-    "rimraf": "*",
     "coveralls": "*",
     "isparta": "*"
   },


### PR DESCRIPTION
Removes rimraf from `devDependencies` as it is present in `dependencies` anyway.
Does away with the warning below:

```
> fly@0.8.3 setup
> npm i && npm run test && npm run symlink

npm WARN package.json Dependency 'rimraf' exists in both dependencies and devDependencies, using 'rimraf@^2.4.2' from dependencies
```
