### PR TITLE
Fixed babel-runtime error

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "babel-core": "*",
-    "babel-runtime": "*",
+    "babel-runtime": "^6.0.14",
     "chokidar": "^1.0.5",
     "clor": "*",
     "co": "^4.5.4",


### PR DESCRIPTION
There's an error with babel when I try to run `fly` after install. I've tracked down the error. It's due to a new version of `babel-runtime` at version 6.1._. I just added a specific version number to `^6.0.14` for now until you can resolve the issue with the new babel-runtime `6.1._` 

```
module.js:339
    throw err;
    ^

Error: Cannot find module 'babel-runtime/helpers/typeof'
    at Function.Module._resolveFilename (module.js:337:15)
    at Function.Module._load (module.js:287:25)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at Object.<anonymous> (/usr/local/Cellar/nvm/0.26.1/versions/node/v4.2.2/lib/node_modules/fly/node_modules/babel-runtime/regenerator/runtime.js:15:16)
    at Module._compile (module.js:435:26)
    at Object.Module._extensions..js (module.js:442:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Module.require (module.js:366:17)
```

![](https://slack-files.com/files-tmb/T02MDPSJX-F0EAF0WAV-8a78e76f21/screen_shot_2015-11-11_at_11.31.43_am_1024.png)
