### PR TITLE
ensure all task descriptions are read. closes #150

### DIFF
--- a/lib/cli/list.js
+++ b/lib/cli/list.js
@@ -32,7 +32,8 @@ module.exports = function (host, options) {
 function each(host, handler) {
 	var rgx = /^\s*\/\*\*\s*@desc\s+(.*)\s*\*\//gm
 	Object.keys(host).forEach(function (taskname) {
-		var desc = rgx.exec(host[taskname])
-		handler(taskname, desc ? desc.pop() : '')
+		var arr = rgx.exec(host[taskname].toString())
+		var desc = arr ? arr.pop().replace(/\*\//, '') : ''
+		handler(taskname, desc)
 	})
 }


### PR DESCRIPTION
change regex pattern. ensure that all functions' bodies are strings before executing regex
