### PR TITLE
Allow for FLY-ESNEXT usage!

### DIFF
--- a/lib/cli/spawn.js
+++ b/lib/cli/spawn.js
@@ -14,10 +14,12 @@ module.exports = function * (dir, hook) {
 	hook = hook || utils.bind
 
 	var flyfile = yield utils.find('flyfile.js', dir)
+	// find & `require()`. will load `fly-esnext` before spawning
+	var plugins = yield loadPlugins(flyfile, hook)
 
 	return new Fly({
 		file: flyfile,
 		host: require(flyfile),
-		plugins: yield loadPlugins(flyfile, hook) // find & `require()`
+		plugins: plugins
 	})
 }

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -71,13 +71,15 @@ function req(name) {
  * @return {Array}  							Flattened (single) array of plugins
  */
 function parse(pkg, blacklist) {
+	var esnext = 'fly-esnext'
+
 	_('parse fly-* plugins from `package.json`')
 
 	if (!pkg) {
 		return []
 	}
 
-	blacklist = blacklist || []
+	blacklist = (blacklist || []).concat(esnext)
 
 	// all declared dependencies
 	var all = ['dependencies', 'devDependencies', 'peerDependencies']
@@ -86,6 +88,11 @@ function parse(pkg, blacklist) {
 		}).map(function (dep) {
 			return Object.keys(pkg[dep])
 		})
+
+	// check if `fly-esnext` is included
+	if (all.indexOf(esnext)) {
+		require(esnext)
+	}
 
 	return flatten(all).filter(function (dep) {
 		// filter down to `fly-` related deps only & ensure NOT in `blacklist`

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -90,7 +90,7 @@ function parse(pkg, blacklist) {
 		})
 
 	// check if `fly-esnext` is included
-	if (all.indexOf(esnext)) {
+	if (all.indexOf(esnext) !== -1) {
 		require(esnext)
 	}
 

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -90,8 +90,14 @@ function parse(pkg, blacklist) {
 		})
 
 	// check if `fly-esnext` is included
-	if (all.indexOf(esnext) !== -1) {
-		require(esnext)
+	if (flatten(all).indexOf(esnext) !== -1) {
+		// @todo: remove limit on node 5+ only
+		if (parseFloat(process.version.substr(1), 10) > 5) {
+			require(esnext)
+		} else {
+			utils.error('Cannot use `fly-esnext` with versions of Node less than 5.0.')
+			process.exit(1)
+		}
 	}
 
 	return flatten(all).filter(function (dep) {


### PR DESCRIPTION
When parsing the package's `fly-` plugins, `fly-esnext` is blacklisted (since it is not a callable task plugin) but manually loaded, if found.

If & when required, [fly-esnext](https://github.com/lukeed/fly-esnext) will allow users to write/use flyfiles and plugins with ES6 and ES7 syntax.

:dancers: 
