### PR TITLE
find & use fly-esnext on node 5+ only

### DIFF
--- a/lib/cli/spawn.js
+++ b/lib/cli/spawn.js
@@ -14,10 +14,12 @@ module.exports = function * (dir, hook) {
 	hook = hook || utils.bind
 
 	var flyfile = yield utils.find('flyfile.js', dir)
+	// find & `require()`. will load `fly-esnext` before spawning
+	var plugins = yield loadPlugins(flyfile, hook)
 
 	return new Fly({
 		file: flyfile,
 		host: require(flyfile),
-		plugins: yield loadPlugins(flyfile, hook) // find & `require()`
+		plugins: plugins
 	})
 }

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -71,13 +71,15 @@ function req(name) {
  * @return {Array}  							Flattened (single) array of plugins
  */
 function parse(pkg, blacklist) {
+	var esnext = 'fly-esnext'
+
 	_('parse fly-* plugins from `package.json`')
 
 	if (!pkg) {
 		return []
 	}
 
-	blacklist = blacklist || []
+	blacklist = (blacklist || []).concat(esnext)
 
 	// all declared dependencies
 	var all = ['dependencies', 'devDependencies', 'peerDependencies']
@@ -86,6 +88,11 @@ function parse(pkg, blacklist) {
 		}).map(function (dep) {
 			return Object.keys(pkg[dep])
 		})
+
+	// check if `fly-esnext` is included
+	if (flatten(all).indexOf(esnext) !== -1) {
+		require(esnext)
+	}
 
 	return flatten(all).filter(function (dep) {
 		// filter down to `fly-` related deps only & ensure NOT in `blacklist`


### PR DESCRIPTION
Same as #154 but allowed on Node 5+ only

Does a hard-check on Node's version, will throw an error & exit if you have `fly-esnext` installed & on Node < 5

@bucaran Temporary... Haven't found an easy solution for other node versions yet. When I do, will update.
