### PR TITLE
Prettier error messages if package.json is missing

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -21,6 +21,11 @@ function load(flyfile, hook) {
 
 	// find `package.json` within the project
 	return findPkg(path.dirname(flyfile)).then(function (fp) {
+		if (!fp) {
+			utils.error('No package.json found!')
+			return []
+		}
+
 		var modules = path.join(path.dirname(fp), 'node_modules')
 
 		// then parse all fly plugins

--- a/lib/utils/find.js
+++ b/lib/utils/find.js
@@ -11,7 +11,7 @@ var _ = debug('fly:find')
  * @return {Promise}               The promise that will resolve to a String
  */
 module.exports = function (filename, dir) {
-	_('find this file: %f', filename)
+	_('find this file: %s', filename)
 	var opts = dir ? {cwd: dir} : {}
 	return findUp(filename, opts)
 }

--- a/lib/utils/read.js
+++ b/lib/utils/read.js
@@ -10,20 +10,25 @@ var fs = require('fs')
  * @return {Promise}               The Promise that will resolve to file's contents
  */
 module.exports = function (filepath) {
-	_('read this file: %f', filepath)
+	_('read this file: %s', filepath)
 
 	return new Promise(function (res, rej) {
-		// send `null` if is a directory
-		if (!fs.statSync(filepath).isFile()) {
-			return res(null)
-		}
-
-		fs.readFile(filepath, function (err, data) {
+		fs.stat(filepath, function (err, stats) {
 			if (err) {
 				return rej(err)
 			}
 
-			return res(data)
+			// send `null` if is a directory
+			if (!stats.isFile()) {
+				return res(null)
+			}
+
+			fs.readFile(filepath, function (err, data) {
+				if (err) {
+					return rej(err)
+				}
+				return res(data)
+			})
 		})
 	})
 }

--- a/lib/utils/write.js
+++ b/lib/utils/write.js
@@ -12,6 +12,6 @@ var co = require('co')
  * @return {Promise}               The Promise
  */
 module.exports = function (filepath, filedata) {
-	_('write this file: %f', filepath)
+	_('write this file: %s', filepath)
 	return co.wrap(writer)(filepath, filedata)
 }


### PR DESCRIPTION
- Change `%f` into `%s` because strings are not floats (doh!)
- Make `fs.stat` async, because async
- If `package.json` is missing, assume no plugins and display a warning
