### PR TITLE
fixes issue with the concat feature

### DIFF
--- a/lib/fly.js
+++ b/lib/fly.js
@@ -293,15 +293,17 @@ Fly.prototype.target = function (dirs, options) {
 	var self = this
 	var _cat = self._.cat
 	var _filters = self._.filters
+	var _globs = self._.globs
 
 	// @todo: utilize `unwrap` here?
 	return co.call(self, function * () {
-		// run thru all globs
-		yield self._.globs.map(function * (glob) {
+		for (var i = 0; i < _globs.length; i++) {
+			var glob = _globs[i]
 			var files = yield expand(glob)
 
 			// run thru all files of each glob
-			yield files.map(function * (file) {
+			for (var x = 0; x < files.length; x++) {
+				var file = files[x]
 				// get data & stats
 				var f = path.parse(file)
 				var data = yield utils.read(file)
@@ -338,8 +340,8 @@ Fly.prototype.target = function (dirs, options) {
 						depth: options.depth
 					})
 				}
-			})
-		})
+			}
+		}
 
 		if (_cat) {
 			yield resolve(dirs, {


### PR DESCRIPTION
I just replace the `map` functions with a `for` loop because currently there are issues around trying to `yield/await` native array functions. I notices this working on a large project a while back and I just used `https://www.npmjs.com/package/async-array-methods` to mimic what I was after. I some cases there's not an issue using the native array methods but occasionally there can be bugs. At least that's what I've noticed.

I've tested this 20 times switching the order of the globs and it seems to be working exactly as expected.

I'm not sure how your test suite is setup but when you get time I would add some tests around this scenario so it doesn't break in future versions of fly. 

I left out the source map thing that we were talking about in #165 so that this can get pushed out quickly. But that feature would still be nice to have back.
