### PR TITLE
Revert "fixes issue with the concat feature"

### DIFF
--- a/lib/fly.js
+++ b/lib/fly.js
@@ -293,17 +293,15 @@ Fly.prototype.target = function (dirs, options) {
 	var self = this
 	var _cat = self._.cat
 	var _filters = self._.filters
-	var _globs = self._.globs
 
 	// @todo: utilize `unwrap` here?
 	return co.call(self, function * () {
-		for (var i = 0; i < _globs.length; i++) {
-			var glob = _globs[i]
+		// run thru all globs
+		yield self._.globs.map(function * (glob) {
 			var files = yield expand(glob)
 
 			// run thru all files of each glob
-			for (var x = 0; x < files.length; x++) {
-				var file = files[x]
+			yield files.map(function * (file) {
 				// get data & stats
 				var f = path.parse(file)
 				var data = yield utils.read(file)
@@ -340,8 +338,8 @@ Fly.prototype.target = function (dirs, options) {
 						depth: options.depth
 					})
 				}
-			}
-		}
+			})
+		})
 
 		if (_cat) {
 			yield resolve(dirs, {


### PR DESCRIPTION
Reverts bucaran/fly#166

The `yield` + `map` loop ensured that all promises were resolved. Standard `for-loop` is not a guarantee that each iteration will complete. 95% of time, tests pass... Not consistent _enough_ to be okay.
