### PR TITLE
Consolidate & Ensure all target() loops will resolve, Add tests

### DIFF
--- a/lib/fly.js
+++ b/lib/fly.js
@@ -298,8 +298,10 @@ Fly.prototype.target = function (dirs, options) {
 	return co(function * () {
 		// run thru all globs
 		for (var glob of self._.globs) {
+			var files = yield expand(glob)
+
 			// run thru all files of each glob
-			for (var file of yield expand(glob)) {
+			yield files.map(function * (file) {
 				// get data & stats
 				var f = path.parse(file)
 				var data = yield utils.read(file)
@@ -336,7 +338,7 @@ Fly.prototype.target = function (dirs, options) {
 						depth: options.depth
 					})
 				}
-			}
+			})
 		}
 
 		if (_cat) {

--- a/lib/fly.js
+++ b/lib/fly.js
@@ -292,18 +292,14 @@ Fly.prototype.target = function (dirs, options) {
 
 	var self = this
 	var _cat = self._.cat
-	var _globs = self._.globs
 	var _filters = self._.filters
 
 	// @todo: utilize `unwrap` here?
 	return co(function * () {
 		// run thru all globs
-		for (var i = 0; i < _globs.length; i++) {
-			var glob = _globs[i]
-			var files = yield expand(glob)
-
+		for (var glob of self._.globs) {
 			// run thru all files of each glob
-			yield files.map(function * (file) {
+			for (var file of yield expand(glob)) {
 				// get data & stats
 				var f = path.parse(file)
 				var data = yield utils.read(file)
@@ -340,7 +336,7 @@ Fly.prototype.target = function (dirs, options) {
 						depth: options.depth
 					})
 				}
-			})
+			}
 		}
 
 		if (_cat) {

--- a/lib/fly.js
+++ b/lib/fly.js
@@ -292,18 +292,18 @@ Fly.prototype.target = function (dirs, options) {
 
 	var self = this
 	var _cat = self._.cat
-	var _filters = self._.filters
 	var _globs = self._.globs
+	var _filters = self._.filters
 
 	// @todo: utilize `unwrap` here?
-	return co.call(self, function * () {
+	return co(function * () {
+		// run thru all globs
 		for (var i = 0; i < _globs.length; i++) {
 			var glob = _globs[i]
 			var files = yield expand(glob)
 
 			// run thru all files of each glob
-			for (var x = 0; x < files.length; x++) {
-				var file = files[x]
+			yield files.map(function * (file) {
 				// get data & stats
 				var f = path.parse(file)
 				var data = yield utils.read(file)
@@ -340,7 +340,7 @@ Fly.prototype.target = function (dirs, options) {
 						depth: options.depth
 					})
 				}
-			}
+			})
 		}
 
 		if (_cat) {

--- a/test/fly.js
+++ b/test/fly.js
@@ -273,10 +273,36 @@ test('✈  fly.clear', function (t) {
 })
 
 test('✈  fly.concat', function (t) {
+	t.plan(4)
+
 	var fly = new Fly()
-	fly.concat('f')
-	t.equal(fly._.cat.base, 'f', 'add concat writer')
-	t.end()
+	var outfile = 'combined.md'
+	var dest = join(fixtures, 'dest')
+
+	co(function * () {
+		fly.concat('f')
+		t.equal(fly._.cat.base, 'f', 'add concat writer, with base reference')
+	})
+
+	co(function * () {
+		// assemble non-expected order
+		yield fly.source([
+			join(fixtures, 'one/two/two-2.md'),
+			join(fixtures, 'one/two/two-1.md'),
+			join(fixtures, 'one/one.md')
+		]).concat(outfile).target(dest)
+
+		fs.readdir(dest, function (_, files) {
+			t.equal(files.length, 1, 'combined to a single file')
+			t.deepEqual(files, [outfile], 'concatenated file is correctly named')
+
+			fs.readFile(join(dest, outfile), 'utf8', function (e, data) {
+				t.deepEqual(data, '# SECOND LEVEL, SECOND FILE\n\n# SECOND LEVEL, FIRST FILE\n\n# FIRST LEVEL\n', 'concatenated file data is ordered correctly')
+			})
+		})
+
+		yield fly.clear(dest)
+	})
 })
 
 test('✈  fly.flatten', function (t) {

--- a/test/fly.js
+++ b/test/fly.js
@@ -316,8 +316,7 @@ test('✈  fly.flatten', function (t) {
 	var resultsZero = ['one.md', 'two-1.md', 'two-2.md']
 	var resultsOne = ['one', 'two']
 
-	function * matches(dir, expect) {
-		var data = fs.readdirSync(dir)
+	function matches(data, expect) {
 		return (expect.length === data.length) && expect.every(function (u, i) {
 			return u === data[i]
 		})
@@ -327,7 +326,11 @@ test('✈  fly.flatten', function (t) {
 		var tar = dest + '-1'
 
 		yield fly.source(src).target(tar)
-		t.ok(yield matches(tar, resultsNormal), 'retain normal pathing if desired depth not specified')
+
+		fs.readdir(tar, function (_, data) {
+			t.ok(matches(data, resultsNormal), 'retain normal pathing if desired depth not specified')
+		})
+
 		yield fly.clear(tar)
 	})
 
@@ -335,7 +338,11 @@ test('✈  fly.flatten', function (t) {
 		var tar = dest + '-2'
 
 		yield fly.source(src).target(tar, {depth: 0})
-		t.ok(yield matches(tar, resultsZero), 'move all files to same directory, no parents')
+
+		fs.readdir(tar, function (_, data) {
+			t.ok(matches(data, resultsZero), 'move all files to same directory, no parents')
+		})
+
 		yield fly.clear(tar)
 	})
 
@@ -343,7 +350,11 @@ test('✈  fly.flatten', function (t) {
 		var tar = dest + '-3'
 
 		yield fly.source(src).target(tar, {depth: 1})
-		t.ok(yield matches(tar, resultsOne), 'keep one parent directory per file')
+
+		fs.readdir(tar, function (_, data) {
+			t.ok(matches(data, resultsOne), 'keep one parent directory per file')
+		})
+
 		yield fly.clear(tar)
 	})
 
@@ -351,7 +362,11 @@ test('✈  fly.flatten', function (t) {
 		var tar = dest + '-4'
 
 		yield fly.source(src).target(tar, {depth: 5})
-		t.ok(yield matches(tar, resultsNormal), 'retain full path if desired depth exceeds path depth')
+
+		fs.readdir(tar, function (_, data) {
+			t.ok(matches(data, resultsNormal), 'retain full path if desired depth exceeds path depth')
+		})
+
 		yield fly.clear(tar)
 	})
 })


### PR DESCRIPTION
- Fixed inconsistency introduced by #166 
- Add additional tests for `concat()` content order
- Fix `fly.flatten`'s assertion helper; `matches` was a faulty generator
