### PR TITLE
Pass full <File> object to filters' options

### DIFF
--- a/lib/fly.js
+++ b/lib/fly.js
@@ -315,7 +315,7 @@ Fly.prototype.target = function (dirs, options) {
 				for (var filter of _filters) {
 					// run the filter's closure fn w/data
 					var res = yield Promise.resolve(filter.cb.apply(
-						self, [data, assign({filename: f.base}, filter.options)].concat(filter.rest)
+						self, [data, assign({file: f}, filter.options)].concat(filter.rest)
 					))
 
 					// once done, retrieve the final `data` & `ext` of output


### PR DESCRIPTION
Previously, only the `base` property of this object was passed into filters, accessible as `options.filename`. This allowed for files' names to be altered while writing.

Now, the entire `<File>` object is passed into filters, allowing any of the file properties to be read and/or changed. The object is nested under the `file` key.

**Warning:** Some plugins may have used the `filename` key in the past. This is now read by calling `options.file.base` instead of `options.filename`

Closes #171 since it achieves the same goal by more reusable means.
