### PR TITLE
Ignore cli arguments after double-hyphen

### DIFF
--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -2,20 +2,21 @@ var parse = require('minimist')
 
 module.exports = function () {
 	return parse(process.argv.slice(2), {
-		default: {
+		'default': {
 			file: '.'
 		},
-		alias: {
+		'alias': {
 			v: 'version',
 			h: 'help',
 			l: 'list',
 			f: 'file',
 			_: 'tasks'
 		},
-		unknown: function (key) {
+		'unknown': function (key) {
 			if (key.slice(0, 1) === '-') {
 				throw new Error({code: 'UNKNOWN_OPTION', key: key})
 			}
-		}
+		},
+		'--': true
 	})
 }


### PR DESCRIPTION
This change allows users of fly to pass command line arguments for their tasks
to consume, provided they are listed after a '--'. This is similiar to how npm
scripts work: http://bit.ly/1W3ddqA.

Refs #164.

Documentation for the '--' minimist option can be found [here](https://github.com/substack/minimist#var-argv--parseargsargs-opts).
