### PR TITLE
Fix `parallel` mode

### DIFF
--- a/lib/fly.js
+++ b/lib/fly.js
@@ -238,8 +238,8 @@ Fly.prototype.start = function (tasks, options) {
 
 	return co.call(self, function * (tasks) {
 		if (options.parallel) {
-			yield tasks.map(function (task) {
-				self.exec(task, value, Object.create(self))
+			yield tasks.map(function * (task) {
+				yield self.exec(task, value, Object.create(self))
 			})
 		} else {
 			for (var task of tasks) {


### PR DESCRIPTION
Was a missing `yield` within `start()`... emerged from an incomplete merge conflict resolution.
Closes #179.
