### PR TITLE
Fixed issue `undefined` not found in Flyfile

### DIFF
--- a/lib/fly.js
+++ b/lib/fly.js
@@ -426,5 +426,5 @@ function getTime() {
  * @return {Boolean}
  */
 function isPlainObject(value) {
-	return Object.prototype.toString.call(value) !== '[object Object]'
+	return ( ({}).toString.call(value) === '[object Object]' && typeof value === 'object' )
 }


### PR DESCRIPTION
Problem with `isPlainObject` method that was set to negative. Also made a bit "safe" type checking as `Object.prototype.toString` could be easy rewritten

![fly](https://cloud.githubusercontent.com/assets/8246283/17751993/7437aad0-64d2-11e6-9130-fb67045b0a08.png)
