### PR TITLE
Cleanup argument handling behaviors

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -236,7 +236,7 @@ Display the version number.
 
 ### IO
 
-#### `Fly.prototype.source (...globs, options)`
+#### `Fly.prototype.source (globs, [options])`
 
 Begin a _yieldable_ sequence.
 
@@ -247,16 +247,23 @@ module.exports.default = function * () {
 }
 ```
 
-#### Options
-  The options are passed to [`node-glob`](https://github.com/isaacs/node-glob#options)
+##### options
+  If needed, any options will be passed to [`node-glob`](https://github.com/isaacs/node-glob#options).
 
-```js
-module.exports.default = function * () {
-  yield this.source("styles/*.scss", "styles/*.sass", { ignore: 'styles/vendors/**/*' })...
-}
-```
+  > **Important:** Should you need the `options` parameter **and** multiple glob selections, your `globs` must be defined as an array. However, a single glob selection may remain a string.
 
-#### `Fly.prototype.target (targets[, {config}])`
+  ```js
+  module.exports.default = function * () {
+    // single glob + options:
+    yield this.source("styles/*.scss", {ignore: 'styles/vendors/**/*'})
+    yield this.source(["styles/*.scss"], {ignore: 'styles/vendors/**/*'})
+
+    // multiple globs + options:
+    yield this.source(["styles/*.scss", "styles/*.sass"], {ignore: 'styles/vendors/**/*'})
+  }
+  ```
+
+#### `Fly.prototype.target (targets[, config])`
 
 Resolve a _yieldable_ sequence. Reduce the data source applying filters and write the result to `targets`.
 

--- a/lib/fly.js
+++ b/lib/fly.js
@@ -220,22 +220,12 @@ Fly.prototype.exec = function * (task, value, instance) {
  * Run a task sequence of 1 or more.
  * Each task's return value is piped into the next task of sequence.
  *
- * @param  {Array}  ...tasks   The list of tasks to start
+ * @param  {Array}  tasks   The list of tasks to start
  * @param  {Object} options The options to begin.
  * @return {Promise}
  */
 Fly.prototype.start = function (tasks, options) {
-	tasks = flatten([].slice.call(arguments))
-	options = tasks.pop()
-
-	if (isPlainObject(options)) {
-		tasks.push(options)
-		options = {}
-	}
-
-	if (!tasks.length) {
-		tasks.push('default')
-	}
+	tasks = arrify(tasks.length ? tasks : 'default')
 
 	options = assign({
 		parallel: false,
@@ -245,17 +235,17 @@ Fly.prototype.start = function (tasks, options) {
 	_('start %o in ' + (options.parallel ? 'parallel' : 'sequence'), tasks)
 
 	var self = this
-	var instance = Object.create(self)
 	var value = options.value
+	var inst = Object.create(self)
 
 	return co.call(self, function * (tasks) {
 		if (options.parallel) {
 			yield tasks.map(function * (task) {
-				yield self.exec(task, value, instance)
+				yield self.exec(task, value, inst)
 			})
 		} else {
 			for (var task of tasks) {
-				value = yield self.exec(task, value, instance)
+				value = yield self.exec(task, value, inst)
 			}
 		}
 		return value

--- a/lib/fly.js
+++ b/lib/fly.js
@@ -402,11 +402,3 @@ function dirpaths(full, depth) {
 function getTime() {
 	return (new Date()).getTime()
 }
-
-/**
- * Checks to see if the value is a plain object
- * @return {Boolean}
- */
-function isPlainObject(value) {
-	return ( ({}).toString.call(value) === '[object Object]' && typeof value === 'object' )
-}

--- a/lib/fly.js
+++ b/lib/fly.js
@@ -81,28 +81,20 @@ module.exports = Fly
  * Compose a new, yeildable sequence.
  * Resets instance's glob, filters, and writer.
  *
- * @param  {String|Array} ...globs The glob selection
- * @param {Object} options If the last argument is an object it's used as options to pass `node-glob`
- * @return                      The current Fly instance.
+ * @param  {String|Array} globs   The glob selection(s)
+ * @param  {Object}       options Any options to pass as `node-glob` config.
+ * @return                        The current Fly instance.
  */
-Fly.prototype.source = function () {
-	var globs = flatten([].slice.call(arguments))
-	var options = globs.pop()
-
-	if (isPlainObject(options)) {
-		globs.push(options)
-		options = {}
-	}
-
-	var files = globs.map(function (glob) {
-		return expand(glob, options)
-	})
+Fly.prototype.source = function (globs, options) {
+	globs = flatten(arrify(globs))
 
 	assign(this, {
 		_: {
 			filters: [],
 			globs: globs,
-			files: Promise.all(files)
+			files: Promise.all(globs.map(function (glob) {
+				return expand(glob, options)
+			}))
 		}
 	})
 

--- a/lib/fly.js
+++ b/lib/fly.js
@@ -256,15 +256,15 @@ Fly.prototype.start = function (tasks, options) {
 
 /**
  * Deferred `rimraf` wrapper
- * @param  {String|Array} paths The paths to delete
+ * @param  {String|Array} globs  The glob selection(s) to delete
  * @return {void}
  */
-Fly.prototype.clear = function (paths) {
-	paths = flatten([].slice.call(arguments))
+Fly.prototype.clear = function (globs) {
+	globs = flatten(arrify(globs))
 
-	_('clear %o', paths)
+	_('clear %o', globs)
 
-	return paths.map(function (p) {
+	return globs.map(function (p) {
 		utils.defer(rimraf)(p)
 	})
 }

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -2,6 +2,12 @@ var fmt = require('./fmt')
 var log = require('./utils').log
 var trace = require('./utils').trace
 
+var evts = {
+	add: 'added',
+	change: 'changed',
+	unlink: 'removed'
+}
+
 module.exports = function () {
 	return this
 		.on('fly_run', function (obj) {
@@ -18,12 +24,7 @@ module.exports = function () {
 		})
 
 		.on('fly_watch_event', function (obj) {
-			// pretty print the event type that happened
-			var type = obj.type.replace(/[a-z]+/, function (match) {
-				return {add: 'Added ', change: 'Changed', unlink: 'Removed '}[match] || ''
-			}).trim()
-
-			log(type + '  ' + fmt.warn.toString(), obj.file)
+			log('File ' + (evts[obj.type] || obj.type.trim()) + ': ' + fmt.warn, obj.file)
 		})
 
 		.on('plugin_load', function (obj) {

--- a/test/fly.js
+++ b/test/fly.js
@@ -256,31 +256,6 @@ test('✈  fly.start (order)', function (t, state) {
 	}
 })
 
-test('✈  fly.start (arguments)', function (t) {
-	t.plan(6)
-	var fly = new Fly({
-		// when running in a sequence both b and c wait while a blocks.
-		// when running in parallel, b and c run while a blocks. state
-		// can only be 3 when each task runs in order.
-		host: {
-			a: function * () {
-				t.pass('test a was run')
-			},
-			b: function * () {
-				t.pass('test b was run')
-			},
-			c: function * () {
-				t.pass('test c was run')
-			}
-		}
-	})
-
-	co(function * () {
-		yield fly.start('a', 'b', 'c', {parallel: true})
-		yield fly.start(['a', 'b', 'c'], {parallel: true})
-	})
-})
-
 test('✈  fly.start (options)', function (t) {
 	t.plan(6)
 	var file = 'fakefile.js'
@@ -302,7 +277,7 @@ test('✈  fly.start (options)', function (t) {
 	})
 
 	co(function * () {
-		yield fly.start('a', 'b', 'c', {parallel: true, value: file})
+		yield fly.start(['a', 'b', 'c'], {parallel: true, value: file})
 		fly.host.a = function * (one, two, three) {
 			t.equals(one, 'one.js', 'one is one.js')
 			t.equals(two, 'two.js', 'two is two.js')
@@ -323,7 +298,7 @@ test('✈  fly.clear', function (t) {
 	var fly = new Fly()
 
 	co(function * () {
-		yield fly.clear.apply(null, paths)
+		yield fly.clear(paths)
 		t.ok(true, 'clear files from a given list of paths')
 	})
 })


### PR DESCRIPTION
With #189 (thanks to @tjbenton!), `fly.source`, `fly.clear`, `fly.start`, and `fly.watch` had their APIs modified and/or refactored to allow for `option` objects to parsed from glob-arrays. 

Despite passing tests, his first pass was unusable at runtime / outside of the `test` environment. (Add "better tests" to the todo list...)

This fills in the gaps while still maintaining the new features.

**Changes:**
- `fly.start` and `fly.source` lose "intelligent" globbing.
  
  Instead of passing an infinite argument list (with an `options` object as the last entry) for a _spread_-like behavior, there are now only two arguments: `globs` and `options`. 
  
  This means that **multiple** glob entries must always be received as an array. 
  
  Single glob selections may or may not choose to be an array.
  
  Examples:
  
  ``` js
  yield this.source("a.js")
  yield this.source("a.js", {ignore: "..."})
  yield this.source(["b.js"], {ignore: "..."})
  yield this.source(["a.js", "b.js", "c.js"], {ignore: "..."})
  // removed: this.source("a.js", "b.js", "c.js")
  
  yield this.start("task1")
  yield this.start("task1", {parallel: false})
  yield this.start(["task1", "task2"])
  yield this.start(["task1", "task2"], {parallel: true})
  // removed: this.start("task1", "task2")
  ```
- Update reporting for watch events
  - Improved performance (slightly) for logging/display logic. 
  - Also changed format from (example) `Changed  ${filepath}` to `File changed: ${filepath}`
- Update documentation to reflect changes
- Fix tests for API changes. 
  - Remove duplicate test group.

---

Thanks to @hzlmn for pointing out the issue & jumpstarting the process.
