### PR TITLE
fix windows path manipulation

### DIFF
--- a/lib/fly.js
+++ b/lib/fly.js
@@ -17,7 +17,7 @@ var rimraf = require('rimraf')
 var utils = require('./utils')
 var Emitter = require('./emitter')
 // shorthands
-var sep = path.sep
+var sep = '/'
 var _ = debug('fly')
 
 function Fly(options) {
@@ -333,16 +333,13 @@ Fly.prototype.target = function (dirs, options) {
 				if (_cat) {
 					_cat.add(f.base, data)
 				} else {
-					// get shared dir between glob & current filepath
-					var dir = path.join.apply(null, f.dir.split(sep).filter(function (filepath) {
-						return glob.split(sep).indexOf(filepath) === -1
-					}))
-
 					// complete the promise & write the output
 					yield resolve(dirs, {
 						data: data,
-						base: path.join(dir, f.name + f.ext),
-						depth: options.depth
+						depth: options.depth,
+						base: f.dir.split(sep).filter(function (filepath) {
+							return glob.split(sep).indexOf(filepath) === -1
+						}).concat(f.name + f.ext).join(sep)
 					})
 				}
 			})


### PR DESCRIPTION
Resolves #200 

Ditched node's `path.sep`, which uses "\", in favor of hardcoded "/" since our ecosystem enforces that notation everywhere.
