### PR TITLE
Modify logic for constructing `file.base`

### DIFF
--- a/lib/fly.js
+++ b/lib/fly.js
@@ -354,12 +354,17 @@ Fly.prototype.target = function (dirs, options) {
 				if (_cat) {
 					_cat.add(f.base, data)
 				} else {
+					var segs = glob.split(sep)
+					var wild = segs.findIndex(function (str) {
+						return str.includes('*')
+					})
 					// complete the promise & write the output
 					yield resolve(dirs, {
 						data: data,
 						depth: options.depth,
 						base: f.dir.split(sep).filter(function (filepath) {
-							return glob.split(sep).indexOf(filepath) === -1
+							var idx = segs.indexOf(filepath)
+							return idx === -1 || wild && (idx >= wild)
 						}).concat(f.name + f.ext).join(sep)
 					})
 				}

--- a/lib/fly.js
+++ b/lib/fly.js
@@ -370,7 +370,7 @@ Fly.prototype.target = function (dirs, options) {
 						depth: options.depth,
 						base: f.dir.split(sep).filter(function (filepath) {
 							var idx = segs.indexOf(filepath)
-							return idx === -1 || wild && (idx >= wild)
+							return idx === -1 || (wild ? (idx >= wild) : idx !== 0)
 						}).concat(f.name + f.ext).join(sep)
 					})
 				}

--- a/lib/fly.js
+++ b/lib/fly.js
@@ -355,9 +355,14 @@ Fly.prototype.target = function (dirs, options) {
 					_cat.add(f.base, data)
 				} else {
 					var segs = glob.split(sep)
-					var wild = segs.findIndex(function (str) {
-						return str.includes('*')
-					})
+					var wild
+					// var wild = segs.findIndex(str => str.includes('*'))
+					for (var i = 0; i < segs.length; i++) {
+						if (segs[i].indexOf('*') !== -1) {
+							wild = i
+						}
+					}
+
 					// complete the promise & write the output
 					yield resolve(dirs, {
 						data: data,

--- a/lib/fly.js
+++ b/lib/fly.js
@@ -327,7 +327,8 @@ Fly.prototype.target = function (dirs, options) {
 		var files = yield self._.files
 
 		for (var i = 0; i < globs.length; i++) {
-			var glob = globs[i]
+			// normalize glob string (for Windows!)
+			var glob = globs[i].replace(path.sep, sep)
 			// run thru all files of each glob
 			yield files[i].map(function * (file) {
 				// get data & stats

--- a/lib/fly.js
+++ b/lib/fly.js
@@ -360,6 +360,7 @@ Fly.prototype.target = function (dirs, options) {
 					for (var i = 0; i < segs.length; i++) {
 						if (segs[i].indexOf('*') !== -1) {
 							wild = i
+							break
 						}
 					}
 

--- a/test/fly.js
+++ b/test/fly.js
@@ -1,12 +1,16 @@
 var fs = require('fs')
 var co = require('co')
+var path = require('path')
 // var { readFile as read } = require('mz/fs')
 var test = require('tape').test
 var touch = require('touch')
 var Fly = require('../lib/fly')
-var join = require('path').join
 
-var fixtures = join(process.cwd(), 'test', 'fixtures')
+var join = path.join
+var resolve = path.resolve
+var relative = path.relative
+
+var fixtures = relative('.', resolve('test', 'fixtures'))
 var flyfile = join(fixtures, 'flyfile.js')
 
 test('✈  fly', function (t) {


### PR DESCRIPTION
When resolving / parsing the `file.base`, sometimes unwanted segments were kept while wanted segments were ignored.

This (hopefully) makes the behavior more consistent. Awaiting test (and appveyor?) results.

Will resolve #216 
