### PR TITLE
Minor package.json fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "node": ">= 4.6.0"
   },
   "xo": {
-    "semicolon": true,
     "esnext": true,
     "ignore": [
       "examples/**/*.js"


### PR DESCRIPTION
``` js
semicolon: true
```

is default in `xo`, so there is no need to reassign it.
