### PR TITLE
[Edge Case]: Allow parsing of alt `package.json` file

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -1,14 +1,16 @@
 'use strict';
 
 const p = require('path');
-const $ = require('./utils');
 const flatten = require('flatten');
 const Promise = require('bluebird');
+const $ = require('./utils');
+const fn = require('./fn');
 
 const co = Promise.coroutine;
 const dirname = p.dirname;
 const join = p.join;
 
+const isObj = fn.isObject;
 const rgx = /^fly-/i;
 
 /**
@@ -25,24 +27,25 @@ function req(name) {
 
 /**
  * Find a sibling `package.json` file & return its contents.
- * @param  {String} file  The path to `package.json`
+ * @param  {Object} file  A `package.json` contents as JSON
  * @return {Array}        The names of all dependencies, flattened
  */
-const getDependencies = co(function * (file) {
-	if (!file || !(yield $.find(file))) {
+function getDependencies(pkg) {
+	if (!pkg) {
 		return [];
 	}
 
-	// parse file contents as Object
-	const pkg = JSON.parse(yield $.read(file));
+	if (!isObj(pkg)) {
+		$.error('Content from `package.json` must be an `Object`!');
+		return [];
+	}
 
 	// get all possible dependencies
 	const deps = ['dependencies', 'devDependencies', 'peerDependencies']
-		.filter(key => key in pkg)
-		.map(dep => Object.keys(pkg[dep]));
+		.filter(key => key in pkg).map(dep => Object.keys(pkg[dep]));
 
 	return flatten(deps);
-});
+}
 
 /**
  * Find & Read a `package.json` file, starting from `dir`.
@@ -82,16 +85,16 @@ const load = co(function * (flyfile) {
 		return [];
 	}
 
-	const modules = join(dirname(pkg.file), 'node_modules');
-
 	// get ALL deps; filter down to fly-only;
-	const deps = yield getDependencies(pkg.file).filter(dep => rgx.test(dep));
+	const deps = getDependencies(pkg.data).filter(dep => rgx.test(dep));
 	const hasNext = deps.indexOf('fly-esnext');
 
 	// if 'fly-esnext' remove from `deps`
 	if (hasNext !== -1) {
 		deps.splice(hasNext, 1);
 	}
+
+	const modules = join(dirname(pkg.file), 'node_modules');
 
 	// format return;
 	return deps.map(str => ({

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -45,23 +45,47 @@ const getDependencies = co(function * (file) {
 });
 
 /**
+ * Find & Read a `package.json` file, starting from `dir`.
+ * @param {String} dir
+ * @yield {Object}      If found, returns as `{file, data}`
+ */
+const getPackage = co(function * (dir) {
+	// traverse upwards from `dir`
+	const file = yield $.find('package.json', dir);
+
+	if (!file) {
+		return false;
+	}
+
+	// check if there's a "fly" config entry
+	const data = JSON.parse(yield $.read(file));
+
+	if (data.fly && data.fly.pkg) {
+		dir = p.resolve(dir, data.fly.pkg);
+		return yield getPackage(dir);
+	}
+
+	return {file: file, data: data};
+});
+
+/**
  * Loads all fly-related plugins!
  * @param  {String} flyfile  The full `flyfile.js` path
  * @return {Array}           All loaded plugins.
  */
 const load = co(function * (flyfile) {
-	// find `package.json` closes to `flyfile`
-	const pkg = yield $.find('package.json', dirname(flyfile));
+	// find a `package.json`, starting with `flyfile` dir
+	const pkg = yield getPackage(dirname(flyfile));
 
 	if (!pkg) {
 		$.error('No `package.json` found!');
 		return [];
 	}
 
-	const modules = join(dirname(pkg), 'node_modules');
+	const modules = join(dirname(pkg.file), 'node_modules');
 
 	// get ALL deps; filter down to fly-only;
-	const deps = yield getDependencies(pkg).filter(dep => rgx.test(dep));
+	const deps = yield getDependencies(pkg.file).filter(dep => rgx.test(dep));
 	const hasNext = deps.indexOf('fly-esnext');
 
 	// if 'fly-esnext' remove from `deps`

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -102,5 +102,6 @@ const load = co(function * (flyfile) {
 
 module.exports = {
 	load: load,
+	getPackage: getPackage,
 	getDependencies: getDependencies
 };

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -106,7 +106,7 @@ const load = co(function * (flyfile) {
 	// format return;
 	return deps.map(str => ({
 		name: str,
-		func: req(join(modules, str))
+		func: req(str, modules)
 	}));
 });
 

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -16,10 +16,17 @@ const rgx = /^fly-/i;
 /**
  * Attempt to dynamically `require()` a file or package
  * @param  {String} name 	The dep-name or filepath to require.
+ * @param  {String} base 	Path to `node_modules` directory.
  */
-function req(name) {
+function req(name, base) {
 	try {
-		return require(name);
+		try {
+			name = require.resolve(name);
+		} catch (_) {
+			name = join(base, name);
+		} finally {
+			return require(name);
+		}
 	} catch (e) {
 		$.alert(e.message);
 	}

--- a/test/fixtures/alt/sub/package.json
+++ b/test/fixtures/alt/sub/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "fake-sub-pkg",
+  "dependencies": {
+  },
+  "fly": {
+    "pkg": "../"
+  }
+}

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -16,9 +16,25 @@ const flyfile = join(altDir, 'flyfile.js');
 
 test('plugins', t => {
 	t.ok(Object.keys(plugs).length, 'export some methods');
-	['load', 'getDependencies'].forEach(k => t.ok(plugs[k] !== undefined, `${k} is defined`));
+	['load', 'getDependencies', 'getPackage'].forEach(k => t.ok(plugs[k] !== undefined, `${k} is defined`));
 	t.end();
 });
+
+test('plugins.getPackage', co(function * (t) {
+	const out1 = yield plugs.getPackage(altDir);
+	t.true($.isObject(out1), 'returns an object');
+	t.true('file' in out1 && 'data' in out1, 'object has `file` and `data` keys');
+	t.equal(out1.file, pkgfile, 'finds the correct `package.json` file');
+	t.true($.isObject(out1.data), 'the `object.data` is also an object');
+	t.true('dependencies' in out1.data, 'the `object.data` contains all `package.json` contents');
+
+	// "fly" > "pkg" tests
+	const subDir = join(altDir, 'sub');
+	const out2 = yield plugs.getPackage(subDir);
+	t.equal(out2.file, pkgfile, 'read `fly.pkg` config to find alternate `package.json` file');
+
+	t.end();
+}));
 
 test('plugins.getDependencies', co(function * (t) {
 	const out1 = yield plugs.getDependencies();

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -37,15 +37,16 @@ test('plugins.getPackage', co(function * (t) {
 }));
 
 test('plugins.getDependencies', co(function * (t) {
-	const out1 = yield plugs.getDependencies();
+	const out1 = plugs.getDependencies();
 	t.true($.isArray(out1) && out1.length === 0, 'via `null` input; returns an empty array');
 
-	const out2 = yield plugs.getDependencies(pkgfile);
+	const pkg = yield plugs.getPackage(pkgfile);
+	const out2 = plugs.getDependencies(pkg.data);
 	t.true($.isArray(out2), 'via valid file; returns an array');
 	t.equal(out2.length, 5, 'via valid file; find all the available dependencies');
 
-	const out3 = yield plugs.getDependencies(join(fixtures, 'asd.json'));
-	t.true($.isArray(out3) && out3.length === 0, 'via 404 file; returns an empty array');
+	const out3 = plugs.getDependencies({});
+	t.true($.isArray(out3) && out3.length === 0, 'via `{}`; returns an empty array');
 
 	t.end();
 }));


### PR DESCRIPTION
Currently, Fly is **assuming** that a project's main `package.json` file is located somewhere between the `flyfile.js` and the project's root directory.

In rare situations, the `package.json` file that we found may not be the one that User wants us to use.

For example:

```
\project
  |- package.json
  |- flyfile.js
  |- \server
      |- package.json
  |- \client
      |- package.json
```

In this contrived**<sup>(•)</sup>** example, we will stop at `project/package.json` when, in fact, the copy at `project/client/package.json` has all the fly-related plugins declared. In this situation, all tasks will fail with `"this.source(...).xo" is not a function`.

> **<sup>(•)</sup>** Yes, `flyfile.js` could be moved to `client/flyfile.js`)

To fix this, User can now place a `"fly"` key in their root `package.json` (the one Fly finds):

```json
// project/package.json

{
  "name": "root-package",
  "fly": {
    "pkg": "./client"
  }
}
```

Now, Fly will recursively read `package.json` files. If a file has this key block declared, Fly will resolve (`path.resolve`) the specified directory **from** the current file's directory. 

> This also means that one can point to a directory outside of `project`.

However, if the new directory does not contain a `package.json` file, Fly will notify User that nothing was found & exit.