### PR TITLE
Fix broken links in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,12 +11,12 @@ Node.js build system based in [generators](https://developer.mozilla.org/en-US/d
 
 * Based in [_co_-routines](https://medium.com/@tjholowaychuk/callbacks-vs-coroutines-174f1fe66127), [generators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) and [promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 * [Callback _heaven_](http://jakearchibald.com/2014/es7-async-functions/)
-* [Concurrent tasks](https://github.com/flyjs/fly/blob/master/docs/README.md#features)
+* [Concurrent tasks](https://github.com/flyjs/fly/tree/v1.4.1/docs/README.md#features)
 * [Robust error handling](https://medium.com/@tjholowaychuk/callbacks-vs-coroutines-174f1fe66127)
-* [Cascading tasks](https://github.com/flyjs/fly/blob/master/CHANGELOG.md#cascading-tasks)
-* Tiny [API](https://github.com/flyjs/fly/blob/master/docs/README.md#api).
+* [Cascading tasks](https://github.com/flyjs/fly/blob/v1.4.1/CHANGELOG.md#cascading-tasks)
+* Tiny [API](https://github.com/flyjs/fly/blob/v1.4.1/docs/README.md#api).
 
-See the [documentation](/docs/README.md) to learn more.
+See the [documentation](https://github.com/flyjs/fly/blob/v1.4.1/docs/README.md) to learn more. Note that internal documentation covers the latest stable release, [v1.4.1](https://github.com/flyjs/fly/releases/tag/v1.4.1). Documentation for v2 will be available soon.
 
 ## Install
 
@@ -57,7 +57,7 @@ x.build = function * () {
 
 ### ES2015 and beyond
 
-If you'd prefer to write your [`flyfile.js`](https://github.com/brj/fly/blob/master/docs/README.md#flyfiles) and [plugins](https://github.com/brj/fly/blob/master/docs/README.md#plugins) with ES6 or ES7 syntax, install [fly-esnext](https://github.com/lukeed/fly-esnext) and that's it :)
+If you'd prefer to write your [`flyfile.js`](https://github.com/flyjs/fly/blob/v1.4.1/docs/README.md#flyfiles) and [plugins](https://github.com/flyjs/fly/blob/v1.4.1/docs/README.md#plugins) with ES6 or ES7 syntax, install [fly-esnext](https://github.com/lukeed/fly-esnext) and that's it :)
 
 ```
 npm i -D fly-esnext

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,9 @@ Node.js build system based in [generators](https://developer.mozilla.org/en-US/d
 * [Cascading tasks](https://github.com/flyjs/fly/blob/v1.4.1/CHANGELOG.md#cascading-tasks)
 * Tiny [API](https://github.com/flyjs/fly/blob/v1.4.1/docs/README.md#api).
 
-See the [documentation](https://github.com/flyjs/fly/blob/v1.4.1/docs/README.md) to learn more. Note that internal documentation covers the latest stable release, [v1.4.1](https://github.com/flyjs/fly/releases/tag/v1.4.1). Documentation for v2 will be available soon.
+See the [documentation](https://github.com/flyjs/fly/blob/v1.4.1/docs/README.md) to learn more.
+
+> Note: Documentation reflects the latest stable release, [v1.4.1](https://github.com/flyjs/fly/releases/tag/v1.4.1). Documentation for v2 will be available soon.
 
 ## Install
 


### PR DESCRIPTION
I'm new to fly and fixed the broken links in the docs to help me and others get up to speed. From what I understand, new docs for v2 will be available per #221, but in the meantime these changes will help people with v1.

I also added a note about the docs covering v1 for now.