### PR TITLE
Rename CLI flag from --pwd to --cwd

### DIFF
--- a/lib/cli/help.js
+++ b/lib/cli/help.js
@@ -11,8 +11,8 @@ Usage
   fly [options] [tasks]
 
 Options
-  -m  --mode=""   Run in "parallel" or "serial". Default: \`serial\`
-  -p  --pwd=""    Set Fly"s home directory. Default: \`.\`
+  -m  --mode=""   Run in "parallel" or "serial". Default: "serial"
+  -d  --cwd=""    Set Fly's home directory. Default: "."
   -h  --help      Display this help message.
   -l  --list      Display available tasks.
   -v  --version   Display Fly version.

--- a/lib/cli/help.js
+++ b/lib/cli/help.js
@@ -18,7 +18,7 @@ Options
   -v  --version   Display Fly version.
 
 Examples
-  fly -p="/demo"
+  fly -d="/demo"
   fly -m=parallel task1 task2
   fly --mode="serial"  task1 task2
 	`

--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -35,7 +35,7 @@ class UnknownError extends Error {
 module.exports = function (arr) {
 	return parse(arr || process.argv.slice(2), {
 		default: {
-			pwd: ".",
+			cwd: ".",
 			mode: "serial"
 		},
 		alias: {
@@ -43,7 +43,7 @@ module.exports = function (arr) {
 			m: "mode",
 			h: "help",
 			l: "list",
-			p: "pwd",
+			d: "cwd",
 			_: "tasks"
 		},
 		unknown: key => {

--- a/lib/cli/spawn.js
+++ b/lib/cli/spawn.js
@@ -8,11 +8,11 @@ const Fly = require("../")
 
 /**
  * Create a new Fly instance
- * @param {String} pwd   The directory to find a `flyfile.js`
+ * @param {String} cwd   The directory to find a `flyfile.js`
  * @return {Fly}         The new Fly instance
  */
-module.exports = co(function * (pwd) {
-	const file = yield find("flyfile.js", pwd)
+module.exports = co(function * (cwd) {
+	const file = yield find("flyfile.js", cwd)
 
 	if (!file) {
 		return new Fly()
@@ -22,7 +22,7 @@ module.exports = co(function * (pwd) {
 	const plugins = yield load(file)
 
 	// spawn options
-	const opts = {pwd, file, plugins}
+	const opts = {cwd, file, plugins}
 
 	try {
 		const esnext = require.resolve("fly-esnext") && require("fly-esnext")

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ class Fly extends Emitter {
 		this.$ = $
 		this._ = {}
 		this.file = opts.file
-		this.root = res(opts.pwd || ".")
+		this.root = res(opts.cwd || ".")
 		this.plugins = opts.plugins || []
 		this.tasks = opts.tasks || opts.file && require(opts.file) || {}
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -94,22 +94,22 @@ test("cli.spawn", co(function * (t) {
 }))
 
 test("cli.options", t => {
-	const d = cli.options() // defaults
-	t.true(d.pwd === ".", "defaults `pwd` to `.`")
-	t.true(d.p === d.pwd, "assigns `p` alias to `pwd`")
-	t.true(d.mode === "serial", "defaults `mode` to `serial`")
-	t.true(d.m === d.mode, "assigns `m` alias to `mode`")
+	const o = cli.options() // defaults
+	t.true(o.cwd === ".", "defaults `cwd` to `.`")
+	t.true(o.d === o.cwd, "assigns `d` alias to `cwd`")
+	t.true(o.mode === "serial", "defaults `mode` to `serial`")
+	t.true(o.m === o.mode, "assigns `m` alias to `mode`")
 
 	const val = {
-		p: "/test",
+		d: "/test",
 		m: "parallel",
 		l: "bare",
 		_: "test1 test2"
 	}
 
-	const max = cli.options(`-p=${val.p} -m=${val.m} --list=${val.l} ${val._}`.split(" "))
+	const max = cli.options(`-d=${val.d} -m=${val.m} --list=${val.l} ${val._}`.split(" "))
 
-	t.true(max.p === max.pwd && max.p === val.p, "assigns `pwd` value")
+	t.true(max.d === max.cwd && max.d === val.d, "assigns `cwd` value")
 	t.true(max.m === max.mode && max.m === val.m, "assigns `mode` value")
 	t.true(max.l === max.list && max.l === val.l, "assigns `list` value")
 	t.true(max._.join(" ") === val._, "assigns `tasks` value")

--- a/test/fly.js
+++ b/test/fly.js
@@ -28,7 +28,7 @@ test("fly.prototype", t => {
 test("fly.constructor", t => {
 	const fake = {
 		file: "fake",
-		pwd: fixtures,
+		cwd: fixtures,
 		tasks: { a: "1" },
 		plugins: [1, 2, 3]
 	}
@@ -45,7 +45,7 @@ test("fly.constructor", t => {
 	const fly2 = new Fly(fake)
 	t.equal(fly2.file, fake.file, "accept custom `file` value")
 	t.equal(fly2.plugins, fake.plugins, "accept custom `plugins` value")
-	t.equal(fly2.root, fake.pwd, "accept custom `root` or `pwd` value")
+	t.equal(fly2.root, fake.cwd, "accept custom `root` or `cwd` value")
 	t.equal(fly2.tasks, fake.tasks, "accept custom `tasks` value")
 
 	t.end()


### PR DESCRIPTION
Using `cwd` as an directory designator makes more sense that `pwd`.

Short aliases also updated from `p` to `d`, for directory.

New `fly -h` looks like this:

```
Usage
  fly [options] [tasks]

Options
  -m  --mode=""  Run in "parallel" or "serial". Default: "serial"
  -d  --cwd=""   Set Fly's home directory. Default: "."
  -h  --help     Display this help message.
  -l  --list     Display available tasks.
  -v  --version  Display Fly version.

Examples
  fly -d="/demo"
  fly -m=parallel task1 task2
  fly --mode="serial" task1 task2
```

> I was the one who named "pwd"; my mistake.