### PR TITLE
Continue Node4 (LTS) Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 
 node_js:
-  - "7"
-  - "6"
+  - 7
+  - 6
+  - 4
 
 git:
   depth: 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ environment:
   matrix:
     - nodejs_version: "7"
     - nodejs_version: "6"
+    - nodejs_version: "4.6"
 
 max_jobs: 4
 clone_depth: 1

--- a/lib/boot.js
+++ b/lib/boot.js
@@ -1,3 +1,5 @@
+"use strict"
+
 const Promise = require('bluebird');
 
 function deferAll(obj) {

--- a/lib/fly.js
+++ b/lib/fly.js
@@ -1,4 +1,6 @@
-const { resolve } = require("path")
+"use strict"
+
+const res = require("path").resolve
 const Promise = require("bluebird")
 const Emitter = require("events")
 const wrapp = require("./wrapp")
@@ -25,7 +27,7 @@ class Fly extends Emitter {
 		}
 
 		this.file = file
-		this.root = resolve(opts.cwd || ".")
+		this.root = res(opts.cwd || ".")
 
 		// construct V8 shapes
 		this.tasks = {}

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -1,11 +1,15 @@
 "use strict"
 
-const { dirname, resolve, join } = require("path")
-const { flatten, isObject } = require("./fn")
-const { coroutine } = require("bluebird")
+const p = require("path")
+const isObject = require("./fn").isObject
+const flatten = require("./fn").flatten
+const co = require("bluebird").coroutine
 const $ = require("./utils")
 
 const rgx = /^fly-/i
+const dirname = p.dirname
+const resolve = p.resolve
+const join = p.join
 
 /**
  * Attempt to dynamically `require()` a file or package
@@ -19,7 +23,7 @@ function req(name, base) {
 		} catch (_) {
 			name = join(base, name)
 		} finally {
-			return require(name)
+			return require(name);
 		}
 	} catch (e) {
 		$.alert(e.message)
@@ -53,7 +57,7 @@ function getDependencies(pkg) {
  * @param {String} dir
  * @yield {Object}      If found, returns as `{file, data}`
  */
-const getPackage = coroutine(function * (dir) {
+const getPackage = co(function * (dir) {
 	// traverse upwards from `dir`
 	const file = yield $.find("package.json", dir)
 
@@ -77,7 +81,7 @@ const getPackage = coroutine(function * (dir) {
  * @param  {String} flyfile  The full `flyfile.js` path
  * @return {Array}           All loaded plugins.
  */
-const load = coroutine(function * (flyfile) {
+const load = co(function * (flyfile) {
 	// find a `package.json`, starting with `flyfile` dir
 	const pkg = yield getPackage(dirname(flyfile))
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -2,7 +2,7 @@
 
 const fmt = require("./fmt")
 const $ = require("./utils/logging")
-const { formatTime } = require("./fn")
+const formatTime = require("./fn").formatTime
 
 module.exports = function () {
 	return this

--- a/lib/task.js
+++ b/lib/task.js
@@ -1,4 +1,6 @@
-const { format, normalize, parse, sep} = require("path")
+"use strict"
+
+const p = require("path")
 const Promise = require("bluebird")
 const wrapp = require("./wrapp")
 const util = require("./utils")
@@ -7,6 +9,10 @@ const $ = require("./fn")
 
 const RGX = /[\\|\/]/g
 const co = Promise.coroutine
+const normalize = p.normalize
+const format = p.format
+const parse = p.parse
+const sep = p.sep
 
 function Task(fly) {
 	// construct shape

--- a/lib/utils/expand.js
+++ b/lib/utils/expand.js
@@ -2,7 +2,8 @@
 
 const Promise = require("bluebird")
 const glob = Promise.promisify(require("glob"))
-const { getUniques, toArray } = require("../fn")
+const getUniques = require("../fn").getUniques
+const toArray = require("../fn").toArray
 
 const isString = val => typeof val === "string"
 const hasIgnore = val => val[0] === "!"

--- a/lib/utils/find.js
+++ b/lib/utils/find.js
@@ -1,8 +1,10 @@
 "use strict"
 
-const { resolve, normalize } = require("path")
-const { promisify } = require("bluebird")
+const p = require("path")
+const promisify = require("bluebird").promisify
 const glob = promisify(require("glob"))
+const normalize = p.normalize
+const resolve = p.resolve
 
 /**
  * Find a file from a given path

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,13 +1,13 @@
 "use strict"
 
-const { coroutine, promisify } = require("bluebird")
+const Promise = require("bluebird")
 const logging = require("./logging")
 
 module.exports = Object.assign(logging, {
-	coroutine,
+	coroutine: Promise.coroutine,
 	expand: require("./expand"),
 	find: require("./find"),
-	promisify,
+	promisify: Promise.promisify,
 	read: require("./read"),
 	trace: require("./trace"),
 	write: require("./write")

--- a/lib/utils/logging.js
+++ b/lib/utils/logging.js
@@ -6,9 +6,9 @@
  * 		- use es2015
  */
 
-const { homedir } = require("os")
 const clor = require("clor")
-const { getTime } = require("../fn")
+const homedir = require("os").homedir
+const getTime = require("../fn").getTime
 
 /**
  * Apply args to the `console[method]` & Add a date stamp.

--- a/lib/utils/read.js
+++ b/lib/utils/read.js
@@ -1,9 +1,10 @@
 "use strict"
 
-const { readFile, stat } = require("fs")
-const { coroutine, promisify } = require("bluebird")
-const read = promisify(readFile)
-const stats = promisify(stat)
+const fs = require("fs")
+const Promise = require("bluebird")
+const stat = Promise.promisify(fs.stat)
+const read = Promise.promisify(fs.readFile)
+const co = Promise.coroutine
 
 /**
  * Return a file's contents. Will not read directory!
@@ -11,7 +12,7 @@ const stats = promisify(stat)
  * @param {Object|String} opts  See `fs.readFile`.
  * @yield {Buffer|String}
  */
-module.exports = coroutine(function * (file, opts) {
-	const s = yield stats(file)
+module.exports = co(function * (file, opts) {
+	const s = yield stat(file)
 	return s.isFile() ? yield read(file, opts) : null
 })

--- a/lib/utils/write.js
+++ b/lib/utils/write.js
@@ -1,9 +1,11 @@
 "use strict"
 
-const { dirname, normalize } = require("path")
-const { coroutine, promisify } = require("bluebird")
-const write = promisify(require("fs").writeFile)
-const mkdirp = promisify(require("mkdirp"))
+const p = require("path")
+const Promise = require("bluebird")
+const write = Promise.promisify(require("fs").writeFile)
+const mkdirp = Promise.promisify(require("mkdirp"))
+const normalize = p.normalize
+const dirname = p.dirname
 
 /**
  * Write to a file with given data.
@@ -11,7 +13,7 @@ const mkdirp = promisify(require("mkdirp"))
  * @param {String} file  The full file"s path.
  * @param {String} data  The data to write.
  */
-module.exports = coroutine(function * (file, data) {
+module.exports = Promise.coroutine(function * (file, data) {
 	try {
 		file = normalize(file)
 		yield mkdirp(dirname(file))

--- a/lib/wrapp.js
+++ b/lib/wrapp.js
@@ -1,3 +1,5 @@
+"use strict"
+
 const Promise = require("bluebird")
 const co = Promise.coroutine
 
@@ -6,12 +8,14 @@ module.exports = function (opts, func) {
 	opts = Object.assign({every: 1, files: 1}, opts)
 	func = opts.func || func
 
-	return co(function * (o, ...args) {
+	return co(function * (o) {
 		o = o || {}
+		const args = []
+		args.push.apply(args, arguments) && args.shift()
 		// grab alias to chosen source type
 		const arr = this._[opts.files ? "files" : "globs"]
 		// wrapper pass all arguments to plugin func
-		const run = s => co(func).call(this, s, o, ...args)
+		const run = s => co(func).apply(this, [s, o].concat(args))
 		// loop thru EACH if `every`, else send full source array
 		yield (opts.every ? Promise.all(arr.map(run)) : run(arr))
 		// send back instance allow chain

--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "build system"
   ],
   "engines": {
-    "node": ">= 6"
+    "node": ">= 4.6"
   }
 }

--- a/test/fixtures/alt/local-plugin.js
+++ b/test/fixtures/alt/local-plugin.js
@@ -2,7 +2,8 @@
 
 module.exports = function (fly, utils) {
 	const self = this
-	fly.plugin("localPlugin", {every: 0}, function * (_, { t }) {
+	fly.plugin("localPlugin", {every: 0}, function * (_, opts) {
+		const t = opts.t
 		t.true("root" in fly && "emit" in fly && "tasks" in fly, "plugin creator receives `fly` instance")
 		t.true("expand" in utils && "find" in utils && "write" in utils, "plugin creator receives `utils` helpers object")
 		t.deepEqual(fly, self, "plugin creator context bound to `fly` instance")


### PR DESCRIPTION
Dropped `4.x` support a bit too early. It turns out that many developers & OSS projects still actively support & use v4, so we should too in order to be approachable. This was my only hesitation before switching.

Nothing changes in terms of performance or features. One `spread` and one `rest` operator were changed within Fly's actual codebase. Every other change is a destructured assignment thru `require()`.

Opens #242 once again. Will revisit in April.