### PR TITLE
Re-add fly.filter to support un-updated fly-plugins

### DIFF
--- a/lib/fly.js
+++ b/lib/fly.js
@@ -80,6 +80,31 @@ class Fly extends Emitter {
 		// safely attach to `plugins` object
 		this.plugins[nxt] = wrapp(opts, func)
 	}
+	
+	// deprecated use plugin instead
+	filter(name, cb) {
+		// register as a common plugin
+		this.plugin(name, {}, function* (file, options){
+			// warn about deprecation
+			this.emit("plugin_warning",
+				{plugin: name, warning: "it used the deprecated 'fly.filter'"})
+
+			// old way to bind file
+			options.file = options.filename = file.toString()
+
+			// call the old plugin callback
+			let res = cb(file.data.toString(), options)
+
+			// some plugins return a promise
+			if(res.then) {
+				res = yield res
+			}
+
+			// bind the old output to the new way
+			file.data = new Buffer(res.code || res.js || res.css || res.data || res)
+			file.base = file.base.replace(/(\..+)$/, res.ext || "$1")
+		})
+	}
 
 	*start(name, opts) {
 		name = name || "default"


### PR DESCRIPTION
I know, this is a big loopback.
But numerous plugins are always still deprecated and could cut the Fly's karma.
(I wanted to move my old build config to Fly and went pissed off)

This addition were written with old source, docs and changelog in mind and manually tried against : fly-pug, fly-buble, fly-postcss, fly-csso, and fly-coffee.

This Pull request is opened for discussion.
I will work on clean tests, if the discussion be favorable.